### PR TITLE
Add relay port view to simulator

### DIFF
--- a/HelloHome.Central.Simulator/src/api.ts
+++ b/HelloHome.Central.Simulator/src/api.ts
@@ -24,7 +24,17 @@ export async function addPulses(portId:number, newPulses:number) : Promise<void>
 }
 
 
-interface History { id:number, timestamp:string, rssi:number, total:number|undefined, temperature:number|undefined, humidity:number|undefined, pressure:number|undefined}
+interface History {
+    id:number,
+    timestamp:string,
+    rssi:number,
+    total:number|undefined,
+    temperature:number|undefined,
+    humidity:number|undefined,
+    pressure:number|undefined,
+    newRelayState?: number | string,
+    relayState?: number | string
+}
 interface Port { id:number, portNumber:number, nodeId:number, $type:string, history:History[] }
 interface Node { id:number, identifier:string, rfAddress:number, signature:string, lastSeen: string, metadata: { name:string }, ports:Port[] }
 

--- a/HelloHome.Central.Simulator/src/components/NodeView/NodeView.tsx
+++ b/HelloHome.Central.Simulator/src/components/NodeView/NodeView.tsx
@@ -3,6 +3,7 @@ import EnvironmentPortView from "./PortView/EnvironmentPort.tsx";
 import PulsePort from "./PortView/PulsePort.tsx";
 import SwitchPort from "./PortView/SwitchPort.tsx";
 import PushButtonPort from "./PortView/PushButtonPort.tsx";
+import RelayPort from "./PortView/RelayPort.tsx";
 
 const NodeView = ({node, clearSlot}: { node: NodeType, clearSlot:() => void}) => {
 
@@ -15,6 +16,7 @@ const NodeView = ({node, clearSlot}: { node: NodeType, clearSlot:() => void}) =>
             case "Pulse" : return <PulsePort port={port}/>
             case "Switch" : return <SwitchPort port={port}/>
             case "PushButton" : return <PushButtonPort port={port}/>
+            case "Relay" : return <RelayPort port={port}/>
         }
     }
 

--- a/HelloHome.Central.Simulator/src/components/NodeView/PortView/EnvironmentPort.tsx
+++ b/HelloHome.Central.Simulator/src/components/NodeView/PortView/EnvironmentPort.tsx
@@ -1,10 +1,18 @@
 import type {PortType} from "../../../api.ts";
 import {useEffect, useState} from "react";
 
+const defaultEnvironment = { temperature: 20, humidity: 50, pressure: 1013 };
+
 const EnvironmentPortView = ({port} : {port:PortType}) => {
-    const [env, setEnv] = useState<{temperature:number, humidity:number, pressure:number}>({ temperature: 20, humidity: 50, pressure: 1013})
+    const [env, setEnv] = useState<{temperature:number, humidity:number, pressure:number}>(defaultEnvironment);
      useEffect(() => {
-        setEnv({ temperature:port.history[0].temperature, humidity:port.history[0].humidity, pressure:port.history[0].pressure})
+         const latest = port.history[0];
+         if (!latest) return;
+         setEnv({
+             temperature: latest.temperature ?? defaultEnvironment.temperature,
+             humidity: latest.humidity ?? defaultEnvironment.humidity,
+             pressure: latest.pressure ?? defaultEnvironment.pressure
+         })
      }, [port]);
 
     return (
@@ -19,7 +27,7 @@ const EnvironmentPortView = ({port} : {port:PortType}) => {
                 <div className="row">
                     <div className="col-4">
                         <label className="form-label mb-1"><i className="bi bi-thermometer me-1"></i>Temperature</label>
-                        <div className="port-value">{port.history[0].temperature}°C</div>
+                        <div className="port-value">{port.history[0]?.temperature ?? "-"}°C</div>
                         <div className="input-group input-group-sm simulate-btn">
                             <input type="number" className="form-control" placeholder="Value"
                                    value={env.temperature} onChange={e => setEnv({...env, temperature: parseInt(e.target.value)})}/>
@@ -27,7 +35,7 @@ const EnvironmentPortView = ({port} : {port:PortType}) => {
                     </div>
                     <div className="col-4">
                         <label className="form-label mb-1"><i className="bi bi-droplet me-1"></i>Humidity</label>
-                        <div className="port-value">{port.history[0].humidity}%</div>
+                        <div className="port-value">{port.history[0]?.humidity ?? "-"}%</div>
                         <div className="input-group input-group-sm simulate-btn">
                             <input type="number" className="form-control" placeholder="Value"
                                    value={env.humidity} onChange={e => setEnv({...env, humidity: parseInt(e.target.value)})}/>
@@ -35,7 +43,7 @@ const EnvironmentPortView = ({port} : {port:PortType}) => {
                     </div>
                     <div className="col-4">
                         <label className="form-label mb-1"><i className="bi bi-speedometer me-1"></i>Pressure</label>
-                        <div className="port-value">{port.history[0].pressure} hPa</div>
+                        <div className="port-value">{port.history[0]?.pressure ?? "-"} hPa</div>
                         <div className="input-group input-group-sm simulate-btn">
                             <input type="number" className="form-control" placeholder="Value"
                                    value={env.pressure} onChange={e => setEnv({...env, pressure: parseInt(e.target.value)})}/>

--- a/HelloHome.Central.Simulator/src/components/NodeView/PortView/RelayPort.tsx
+++ b/HelloHome.Central.Simulator/src/components/NodeView/PortView/RelayPort.tsx
@@ -1,0 +1,39 @@
+import type {PortType} from "../../../api.ts";
+import {useMqtt} from "../../MqttProvider.tsx";
+
+const RelayPort = ({port}: { port: PortType }) => {
+    const { publish } = useMqtt();
+    const lastState = port.history[0]?.newRelayState ?? port.history[0]?.relayState;
+    const normalizedState = typeof lastState === "string" ? lastState.toLowerCase() : lastState;
+    const isOn = normalizedState === 1 || normalizedState === "1" || normalizedState === "on";
+    const relayStateLabel = normalizedState === undefined ? "Unknown" : (isOn ? "On" : "Off");
+
+    const handleClick = (state: "on" | "off") => () => {
+        publish(`Node/${port.nodeId}/relay/${port.portNumber}/status`, state);
+    };
+
+    return (
+        <div className="port-section">
+            <div className="port-header">
+                <div className="sensor-icon switch-icon">
+                    <i className="bi bi-lightning-charge"></i>
+                </div>
+                <strong>Relay</strong>
+            </div>
+            <div className="port-item">
+                <label className="form-label mb-1">Current State</label>
+                <div className="port-value">{relayStateLabel}</div>
+                <div className="btn-group simulate-btn" role="group">
+                    <button type="button" className="btn btn-success btn-sm" onClick={handleClick("on")}>
+                        <i className="bi bi-power me-1"></i> Turn On
+                    </button>
+                    <button type="button" className="btn btn-secondary btn-sm" onClick={handleClick("off")}>
+                        <i className="bi bi-power me-1"></i> Turn Off
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default RelayPort;

--- a/HelloHome.Central.Simulator/tsconfig.app.json
+++ b/HelloHome.Central.Simulator/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/assets/clients_files"]
 }


### PR DESCRIPTION
## Summary
- add a relay port view that shows current state and publishes MQTT commands to toggle it
- handle Relay ports in the node view and broaden port history typing for relay state fields
- exclude generated client assets from TypeScript build and harden environment port defaults

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924ab919f488328ac7dab148c6bd229)