### PR TITLE
Make simulator port views more compact

### DIFF
--- a/HelloHome.Central.Simulator/src/App.css
+++ b/HelloHome.Central.Simulator/src/App.css
@@ -174,40 +174,80 @@ body {
 }
 
 .port-section {
-    margin-bottom: 20px;
+    border: 1px solid #e9ecef;
+    border-radius: 10px;
+    padding: 12px;
+    background-color: #fff;
+    margin-bottom: 14px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.03);
 }
 
 .port-header {
-    background-color: #f8f9fa;
-    padding: 10px;
-    border-radius: 5px;
-    margin-bottom: 10px;
     display: flex;
     align-items: center;
     gap: 10px;
+    margin-bottom: 10px;
 }
 
 .port-header i {
-    font-size: 1.5rem;
+    font-size: 1.25rem;
 }
 
-.port-item {
+.port-title {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    line-height: 1.1;
+}
+
+.port-title small {
+    color: #6c757d;
+    font-size: 0.8rem;
+}
+
+.port-body {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: flex-start;
+}
+
+.port-stat {
+    flex: 1 1 150px;
     background-color: #f8f9fa;
-    padding: 15px;
-    border-radius: 5px;
-    margin-bottom: 10px;
-    border-left: 3px solid var(--info-color);
+    border: 1px solid #e9ecef;
+    border-radius: 8px;
+    padding: 10px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.port-stat .label {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: #6c757d;
+    font-size: 0.9rem;
+    margin: 0;
 }
 
 .port-value {
-    font-size: 1.5rem;
-    font-weight: bold;
+    font-size: 1.25rem;
+    font-weight: 700;
     color: var(--secondary-color);
-    margin: 10px 0;
+    margin: 0;
 }
 
-.simulate-btn {
-    margin-top: 10px;
+.simulate-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+}
+
+.simulate-group .form-control {
+    max-width: 120px;
 }
 
 .status-badge {

--- a/HelloHome.Central.Simulator/src/components/NodeView/PortView/EnvironmentPort.tsx
+++ b/HelloHome.Central.Simulator/src/components/NodeView/PortView/EnvironmentPort.tsx
@@ -21,36 +21,37 @@ const EnvironmentPortView = ({port} : {port:PortType}) => {
                 <div className="sensor-icon environment-icon">
                     <i className="bi bi-thermometer-half"></i>
                 </div>
-                <strong>Environment Port</strong>
+                <div className="port-title">
+                    <strong>Environment</strong>
+                    <small>Port #{port.portNumber}</small>
+                </div>
             </div>
-            <div className="port-item">
-                <div className="row">
-                    <div className="col-4">
-                        <label className="form-label mb-1"><i className="bi bi-thermometer me-1"></i>Temperature</label>
-                        <div className="port-value">{port.history[0]?.temperature ?? "-"}°C</div>
-                        <div className="input-group input-group-sm simulate-btn">
-                            <input type="number" className="form-control" placeholder="Value"
-                                   value={env.temperature} onChange={e => setEnv({...env, temperature: parseInt(e.target.value)})}/>
-                        </div>
+            <div className="port-body">
+                <div className="port-stat">
+                    <p className="label"><i className="bi bi-thermometer"></i>Temperature</p>
+                    <div className="port-value">{port.history[0]?.temperature ?? "-"}°C</div>
+                    <div className="simulate-group">
+                        <input type="number" className="form-control form-control-sm" placeholder="Value"
+                               value={env.temperature} onChange={e => setEnv({...env, temperature: parseInt(e.target.value)})}/>
                     </div>
-                    <div className="col-4">
-                        <label className="form-label mb-1"><i className="bi bi-droplet me-1"></i>Humidity</label>
-                        <div className="port-value">{port.history[0]?.humidity ?? "-"}%</div>
-                        <div className="input-group input-group-sm simulate-btn">
-                            <input type="number" className="form-control" placeholder="Value"
-                                   value={env.humidity} onChange={e => setEnv({...env, humidity: parseInt(e.target.value)})}/>
-                        </div>
+                </div>
+                <div className="port-stat">
+                    <p className="label"><i className="bi bi-droplet"></i>Humidity</p>
+                    <div className="port-value">{port.history[0]?.humidity ?? "-"}%</div>
+                    <div className="simulate-group">
+                        <input type="number" className="form-control form-control-sm" placeholder="Value"
+                               value={env.humidity} onChange={e => setEnv({...env, humidity: parseInt(e.target.value)})}/>
                     </div>
-                    <div className="col-4">
-                        <label className="form-label mb-1"><i className="bi bi-speedometer me-1"></i>Pressure</label>
-                        <div className="port-value">{port.history[0]?.pressure ?? "-"} hPa</div>
-                        <div className="input-group input-group-sm simulate-btn">
-                            <input type="number" className="form-control" placeholder="Value"
-                                   value={env.pressure} onChange={e => setEnv({...env, pressure: parseInt(e.target.value)})}/>
-                            <button className="btn btn-primary" type="button">
-                                <i className="bi bi-play-fill"></i> Simulate
-                            </button>
-                        </div>
+                </div>
+                <div className="port-stat">
+                    <p className="label"><i className="bi bi-speedometer"></i>Pressure</p>
+                    <div className="port-value">{port.history[0]?.pressure ?? "-"} hPa</div>
+                    <div className="simulate-group">
+                        <input type="number" className="form-control form-control-sm" placeholder="Value"
+                               value={env.pressure} onChange={e => setEnv({...env, pressure: parseInt(e.target.value)})}/>
+                        <button className="btn btn-primary btn-sm" type="button">
+                            <i className="bi bi-play-fill"></i> Simulate
+                        </button>
                     </div>
                 </div>
             </div>

--- a/HelloHome.Central.Simulator/src/components/NodeView/PortView/PulsePort.tsx
+++ b/HelloHome.Central.Simulator/src/components/NodeView/PortView/PulsePort.tsx
@@ -7,26 +7,29 @@ const PulsePort = ({port}: {port:PortType}) => {
         await addPulses(portId, newPulses);
     }
     return (
-        <>
-            <div className="port-section">
-                <div className="port-header">
-                    <div className="sensor-icon pulse-icon">
-                        <i className="bi bi-activity"></i>
-                    </div>
-                    <strong>Pulse Sensor (Energy Meter)</strong>
+        <div className="port-section">
+            <div className="port-header">
+                <div className="sensor-icon pulse-icon">
+                    <i className="bi bi-activity"></i>
                 </div>
-                <div className="port-item">
-                    <label className="form-label mb-1">Pulse Count</label>
+                <div className="port-title">
+                    <strong>Pulse Sensor</strong>
+                    <small>Port #{port.portNumber}</small>
+                </div>
+            </div>
+            <div className="port-body">
+                <div className="port-stat">
+                    <p className="label">Pulse Count</p>
                     <div className="port-value">{port?.history[0]?.total}</div>
-                    <div className="input-group input-group-sm simulate-btn">
-                        <input type="number" className="form-control" placeholder="Pulse count" value={pulses} onChange={e => setNewPulse(parseInt(e.target.value))} />
-                        <button className="btn btn-warning" type="button" onClick={sendPulse(port.id, pulses)}>
+                    <div className="simulate-group">
+                        <input type="number" className="form-control form-control-sm" placeholder="Pulse count" value={pulses} onChange={e => setNewPulse(parseInt(e.target.value))} />
+                        <button className="btn btn-warning btn-sm" type="button" onClick={sendPulse(port.id, pulses)}>
                             <i className="bi bi-play-fill"></i> Send
                         </button>
                     </div>
                 </div>
             </div>
-        </>
+        </div>
     );
 }
 

--- a/HelloHome.Central.Simulator/src/components/NodeView/PortView/PushButtonPort.tsx
+++ b/HelloHome.Central.Simulator/src/components/NodeView/PortView/PushButtonPort.tsx
@@ -19,13 +19,19 @@ const PushButtonPort = ({port}: {port:PortType}) => {
                 <div className="sensor-icon switch-icon">
                     <i className="bi bi-toggle-on"></i>
                 </div>
-                <strong>Push Sensor</strong>
+                <div className="port-title">
+                    <strong>Push Sensor</strong>
+                    <small>Port #{port.portNumber}</small>
+                </div>
             </div>
-            <div className="port-item">
-                <div className="btn-group simulate-btn" role="group">
-                    <button type="button" className="btn btn-success btn-sm switch-on" onClick={handleClick}>
-                        <i className="bi bi-toggle-on me-1"></i> Simulate Push
-                    </button>
+            <div className="port-body">
+                <div className="port-stat">
+                    <p className="label">Trigger</p>
+                    <div className="simulate-group" role="group">
+                        <button type="button" className="btn btn-success btn-sm switch-on" onClick={handleClick}>
+                            <i className="bi bi-toggle-on me-1"></i> Simulate Push
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/HelloHome.Central.Simulator/src/components/NodeView/PortView/RelayPort.tsx
+++ b/HelloHome.Central.Simulator/src/components/NodeView/PortView/RelayPort.tsx
@@ -18,18 +18,23 @@ const RelayPort = ({port}: { port: PortType }) => {
                 <div className="sensor-icon switch-icon">
                     <i className="bi bi-lightning-charge"></i>
                 </div>
-                <strong>Relay</strong>
+                <div className="port-title">
+                    <strong>Relay</strong>
+                    <small>Port #{port.portNumber}</small>
+                </div>
             </div>
-            <div className="port-item">
-                <label className="form-label mb-1">Current State</label>
-                <div className="port-value">{relayStateLabel}</div>
-                <div className="btn-group simulate-btn" role="group">
-                    <button type="button" className="btn btn-success btn-sm" onClick={handleClick("on")}>
-                        <i className="bi bi-power me-1"></i> Turn On
-                    </button>
-                    <button type="button" className="btn btn-secondary btn-sm" onClick={handleClick("off")}>
-                        <i className="bi bi-power me-1"></i> Turn Off
-                    </button>
+            <div className="port-body">
+                <div className="port-stat">
+                    <p className="label">Current State</p>
+                    <div className="port-value">{relayStateLabel}</div>
+                    <div className="simulate-group" role="group">
+                        <button type="button" className="btn btn-success btn-sm" onClick={handleClick("on")}>
+                            <i className="bi bi-power me-1"></i> Turn On
+                        </button>
+                        <button type="button" className="btn btn-secondary btn-sm" onClick={handleClick("off")}>
+                            <i className="bi bi-power me-1"></i> Turn Off
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/HelloHome.Central.Simulator/src/components/NodeView/PortView/SwitchPort.tsx
+++ b/HelloHome.Central.Simulator/src/components/NodeView/PortView/SwitchPort.tsx
@@ -19,18 +19,23 @@ const SwitchPort = ({port}: {port:PortType}) => {
                 <div className="sensor-icon switch-icon">
                     <i className="bi bi-toggle-on"></i>
                 </div>
-                <strong>Switch Sensor</strong>
+                <div className="port-title">
+                    <strong>Switch Sensor</strong>
+                    <small>Port #{port.portNumber}</small>
+                </div>
             </div>
-            <div className="port-item">
-                <label className="form-label mb-1">Switch State</label>
-                <div className="port-value">STATE</div>
-                <div className="btn-group simulate-btn" role="group">
-                    <button type="button" className="btn btn-success btn-sm switch-on" onClick={handleClick}>
-                        <i className="bi bi-toggle-on me-1"></i> Simulate ON
-                    </button>
-                    <button type="button" className="btn btn-secondary btn-sm switch-off" onClick={handleClick}>
-                        <i className="bi bi-toggle-off me-1"></i> Simulate OFF
-                    </button>
+            <div className="port-body">
+                <div className="port-stat">
+                    <p className="label">Switch State</p>
+                    <div className="port-value">STATE</div>
+                    <div className="simulate-group" role="group">
+                        <button type="button" className="btn btn-success btn-sm switch-on" onClick={handleClick}>
+                            <i className="bi bi-toggle-on me-1"></i> Simulate ON
+                        </button>
+                        <button type="button" className="btn btn-secondary btn-sm switch-off" onClick={handleClick}>
+                            <i className="bi bi-toggle-off me-1"></i> Simulate OFF
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- restyle simulator port cards with a compact layout and inline headers
- update environment, pulse, switch, push, and relay port views to match the new condensed styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925f26ee59483289e086d8af81d4ff2)